### PR TITLE
Adding node version constraints and updating readme

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Boilerplate to create an embedded Shopify app made with Node, [Next.js](https://nextjs.org/), [Shopify-koa-auth](https://github.com/Shopify/quilt/tree/master/packages/koa-shopify-auth), [Polaris](https://github.com/Shopify/polaris-react), and [App Bridge React](https://shopify.dev/tools/app-bridge/react-components).
 
+Recommended NodeJS version: v16
+
 ## Installation
 
 Using the [Shopify CLI](https://github.com/Shopify/shopify-cli) run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "shopify-app-node",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -49,6 +48,10 @@
         "prettier": "2.2.1",
         "react-addons-test-utils": "15.6.2",
         "react-test-renderer": "16.14.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <=17.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@apollo/react-common": {

--- a/package.json
+++ b/package.json
@@ -69,5 +69,9 @@
     "*.{js,css,json,md}": [
       "prettier --write"
     ]
+  },
+  "engines": {
+    "npm": ">=7.0.0",
+    "node": ">=12.22.0 <=17.0.0"
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

There are a number of issues relating to node version errors so I believe it would be prudent to specify the required node version.

This should be non-breaking

Fixes #688 

### WHAT is this pull request doing?

Adding `engines` to package.json to be inline with package convention. node v17 has major breaking changes so I don't foresee this package being v17 compatible. I also limited the lower bound to v12 since that is the version required by NextJS
