### PR TITLE
Correct return type for webhookHandler

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -29,8 +29,9 @@ Shopify.Context.initialize({
 const ACTIVE_SHOPIFY_SHOPS = {};
 Shopify.Webhooks.Registry.addHandler("APP_UNINSTALLED", {
   path: "/webhooks",
-  webhookHandler: async (topic, shop, body) =>
-    delete ACTIVE_SHOPIFY_SHOPS[shop],
+  webhookHandler: async (topic, shop, body) => {
+    delete ACTIVE_SHOPIFY_SHOPS[shop]
+  },
 });
 
 // export for test use only


### PR DESCRIPTION
webhookHandler should return void, not a boolean. This fixes a type error.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The return type for webhookHandler was Promise<boolean>, which gave a lint error (did not match the WebhookHandlerFunction return type).

### WHAT is this pull request doing?

webhookHandler now returns Promise<void>.