### PR TITLE
Include express body parsing after webhooks

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -77,6 +77,8 @@ export async function createServer(
     }
   });
 
+  app.use(express.json())
+
   app.use((req, res, next) => {
     const shop = req.query.shop;
     if (Shopify.Context.IS_EMBEDDED_APP && shop) {


### PR DESCRIPTION
### WHY are these changes introduced?
When working with the sample app starter code @lizkenyon and I struggled with why our POST was not working for a long time. We thought it could be due to the req body not being parsed properly, but when adding express.json at the top (as conventional) it caused the app to just hang.

Eventually we found conversation about this is this [issue](https://github.com/Shopify/shopify-node-api/issues/256#issuecomment-1018895699) - and figured out the parser needed to be included after the webhook registration. This should be included in the sample app for convenience.


### WHAT is this pull request doing?
Includes express.json after webook registration for the new endpoints people will be adding to the starter code.