### PR TITLE
Fix: Adds setting needed for pnpm dev to work

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 auto-install-peers=true
+shamefully-hoist=true


### PR DESCRIPTION
### WHY are these changes introduced?

Using `pnpm dev` to do a local deployment resulted in some files (within `node_modules/.pnpm`) not being found (returning `404` to FE).

### WHAT is this pull request doing?

Adds `shamefully-hoist=true` to support `pnpm`, in combination with https://github.com/Shopify/starter-react-frontend-app/pull/71