### PR TITLE
Fix: Update submodule repo after rename

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "web/frontend"]
 	path = web/frontend
-	url = https://github.com/Shopify/starter-react-frontend-app.git
+	url = https://github.com/Shopify/shopify-frontend-template-react.git


### PR DESCRIPTION
Changing the repo url in `.gitmodules` after rename (previous URL was just redirecting using GitHub)