### PR TITLE
Add .dockerignore to speed up build

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+frontend/node_modules
+frontend/dist

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,7 +5,6 @@ ENV SHOPIFY_API_KEY=$SHOPIFY_API_KEY
 EXPOSE 8081/tcp
 WORKDIR /app
 COPY . .
-RUN rm -rf node_modules && npm install
-RUN cd frontend && rm -rf node_modules && npm install
-RUN cd frontend && rm -rf dist && npm run build
+RUN npm install
+RUN cd frontend && npm install && npm run build
 CMD npm run serve


### PR DESCRIPTION
### WHY are these changes introduced?

Adding `.dockerignore` for `node_modules` and `dist` allows removal of `rm -rf` commands from `Dockerfile` which enhances build speed.

### WHAT is this pull request doing?

☝🏻 