### PR TITLE
Add cli_three to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [main]
+    branches: [cli_three]
   pull_request:
-    branches: [main]
+    branches: [cli_three]
 
 jobs:
   build:
@@ -22,13 +22,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: c-hive/gha-yarn-cache@v2
-        with:
-          directory: web
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
-      - run: "cat .env.test >> $GITHUB_ENV"
+      - name: Build FE for production test
+        working-directory: ./web/frontend
+        run: yarn install && yarn build
       - run: NODE_ENV=test yarn test


### PR DESCRIPTION
### WHY are these changes introduced?

CI workflow is configured to only run on `main` branch

### WHAT is this pull request doing?

Change `main` to `cli_three` branch for CI workflow, and remove yarn cache (not needed here)