### PR TITLE
Omit GDPR webhook warnings

### DIFF
--- a/web/middleware/auth.js
+++ b/web/middleware/auth.js
@@ -1,4 +1,5 @@
 import { Shopify } from "@shopify/shopify-api";
+import { gdprTopics } from "@shopify/shopify-api/dist/webhooks/registry.js";
 
 import ensureBilling from "../helpers/ensure-billing.js";
 import topLevelAuthRedirect from "../helpers/top-level-auth-redirect.js";
@@ -63,15 +64,10 @@ export default function applyAuthMiddleware(
       });
 
       Object.entries(responses).map(([topic, response]) => {
-        if (!response.success) {
-          // The response from registerAll will include errors for the GDPR topics.  These can be safely ignored.
-          // To register the GDPR topics, please set the appropriate webhook endpoint in the
-          // 'GDPR mandatory webhooks' section of 'App setup' in the Partners Dashboard.
-          //
-          // To avoid logging the GDPR webhook registration error here, you can add
-          //   import {gdprTopics} from '@shopify/shopify-api/dist/webhooks/registry.js';
-          // to the top of this file and then change the if statement above to filter out the GDPR topics:
-          //   if (!response.success && !gdprTopics.includes(topic))
+        // The response from registerAll will include errors for the GDPR topics.  These can be safely ignored.
+        // To register the GDPR topics, please set the appropriate webhook endpoint in the
+        // 'GDPR mandatory webhooks' section of 'App setup' in the Partners Dashboard.
+        if (!response.success && !gdprTopics.includes(topic)) {
           console.log(
             `Failed to register ${topic} webhook: ${response.result.errors[0].message}`
           );


### PR DESCRIPTION
We currently let the warning about GDPR webhooks through when completing OAuth and setting up webhooks, which can be a bit confusing since there is no actual error.

This PR simply applies the suggested code to silence the warning messages for those webhooks.