### PR TITLE
Add Session to verifyRequest middleware

### DIFF
--- a/server/middleware/verify-request.js
+++ b/server/middleware/verify-request.js
@@ -7,13 +7,18 @@ const TEST_GRAPHQL_QUERY = `
   }
 }`;
 
-export default function verifyRequest(app, { returnHeader = true } = {}) {
+export default function verifyRequest(app, { returnHeader = true } = {}, useOnlineTokens = true) {
   return async (req, res, next) => {
     const session = await Shopify.Utils.loadCurrentSession(
       req,
       res,
-      app.get("use-online-tokens")
+      app?.get("use-online-tokens") || useOnlineTokens
     );
+
+    res.locals.shopify = {
+      ...res.locals.shopify,
+      session
+    }
 
     let shop = req.query.shop;
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The verifyRequest middleware makes a request to OAuth in order to load the current session, loadCurrentSession from Shopify api utils also does this. This leads to scenarios where 2 requests are being made for the same session where only 1 is needed.

For example in the current `products-count` example on `main`, verifyRequest is making a request and `loadCurrentSession` is making a request

```js
  app.get("/products-count", verifyRequest(app), async (req, res) => {
    const session = await Shopify.Utils.loadCurrentSession(req, res, true);
    const { Product } = await import(
      `@shopify/shopify-api/dist/rest-resources/${Shopify.Context.API_VERSION}/index.js`
    );

    const countData = await Product.count({ session });
    res.status(200).send(countData);
  });
```

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

All this pull request is doing is making the `app` variable optional, since it is only used to get the `use-online-tokens` Boolean and adding an optional `useOnlineTokens` Boolean defaulting to `true`. This is so the end user doesn't have to extract the express app into its own file for instantiation every time the middleware needs to be used just to grab a Boolean.

Then we're saving the session in a local, valid through the lifetime of the request. [See express docs on locals
](https://expressjs.com/en/api.html#app.properties)

Now the end user just has to access the session through the local without needing an extra import or lifting the express app.

### Proof of concept
![image](https://user-images.githubusercontent.com/13829417/173484353-4d9c3d3f-6955-4b96-a515-5a673f216aee.png)

