### PR TITLE
Change session storage to SQLite

### DIFF
--- a/web/__tests__/server.test.js
+++ b/web/__tests__/server.test.js
@@ -25,7 +25,7 @@ vi.mock(`${process.cwd()}/middleware/verify-request.js`, () => ({
   }),
 }));
 
-describe("starter-node-app server", async () => {
+describe("shopify-app-template-node server", async () => {
   const { app } = await serve(process.cwd(), false);
 
   test("loads html on /", async () => {

--- a/web/__tests__/server.test.js
+++ b/web/__tests__/server.test.js
@@ -95,7 +95,7 @@ describe("shopify-app-template-node server", async () => {
 
   test("goes to top level auth in oauth flow when there is no cookie", async () => {
     const response = await request(app)
-      .get("/api/auth")
+      .get("/api/auth?shop=test-shop.myshopify.test")
       .set("Accept", "text/html");
 
     expect(response.status).toEqual(302);
@@ -116,7 +116,7 @@ describe("shopify-app-template-node server", async () => {
     const { headers } = await request(app).get("/api/auth/toplevel");
 
     const response = await request(app)
-      .get("/api/auth")
+      .get("/api/auth?shop=test-shop")
       .set("Cookie", ...headers["set-cookie"]);
 
     expect(response.status).toEqual(302);

--- a/web/index.js
+++ b/web/index.js
@@ -19,6 +19,8 @@ const isTest = process.env.NODE_ENV === "test" || !!process.env.VITE_TEST_BUILD;
 const DEV_INDEX_PATH = `${process.cwd()}/frontend/`;
 const PROD_INDEX_PATH = `${process.cwd()}/frontend/dist/`;
 
+const DB_PATH = `${process.cwd()}/database.sqlite`;
+
 Shopify.Context.initialize({
   API_KEY: process.env.SHOPIFY_API_KEY,
   API_SECRET_KEY: process.env.SHOPIFY_API_SECRET,
@@ -28,7 +30,7 @@ Shopify.Context.initialize({
   API_VERSION: ApiVersion.April22,
   IS_EMBEDDED_APP: true,
   // This should be replaced with your preferred storage strategy
-  SESSION_STORAGE: new Shopify.Session.MemorySessionStorage(),
+  SESSION_STORAGE: new Shopify.Session.SQLiteSessionStorage(DB_PATH),
 });
 
 // Storing the currently active shops in memory will force them to re-login when your server restarts. You should

--- a/web/middleware/auth.js
+++ b/web/middleware/auth.js
@@ -9,6 +9,11 @@ export default function applyAuthMiddleware(
   { billing = { required: false } } = { billing: { required: false } }
 ) {
   app.get("/api/auth", async (req, res) => {
+    if (!req.query.shop) {
+      res.status(500);
+      return res.send('No shop provided');
+    }
+
     if (!req.signedCookies[app.get("top-level-oauth-cookie")]) {
       return res.redirect(`/api/auth/toplevel?shop=${req.query.shop}`);
     }

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "starter-node-app",
+  "name": "shopify-app-template-node",
   "private": true,
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
### WHY are these changes introduced?

`README.md` file indicates that this template should create/use a `database.sqlite` file - however, template was set up to use memory session storage.

### WHAT is this pull request doing?

- Change session storage to SQLite
- Also changed references to starter-node-app to shopify-app-template-node
