### PR TITLE
Move docker files up one level

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+web/node_modules
+web/frontend/node_modules
+web/frontend/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /app
 COPY web .
 RUN npm install
 RUN cd frontend && npm install && npm run build
-CMD ["npm" "run" "serve"]
+CMD ["npm", "run", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG SHOPIFY_API_KEY
 ENV SHOPIFY_API_KEY=$SHOPIFY_API_KEY
 EXPOSE 8081
 WORKDIR /app
-COPY . .
+COPY web .
 RUN npm install
 RUN cd frontend && npm install && npm run build
-CMD npm run serve
+CMD ["npm" "run" "serve"]

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-frontend/node_modules
-frontend/dist

--- a/web/docs/fly-io.md
+++ b/web/docs/fly-io.md
@@ -3,24 +3,45 @@
 ## Create a fly.io account
 
 1. Go to [fly.io](https://fly.io) and click on _Get Started_.
-2. [Download and install](https://fly.io/docs/flyctl/installing/) the Fly CLI
-3. From the command line, sign up for Fly: `flyctl auth signup`.  You can sign up with an email address or with a GitHub account.
-4. Fill in credit card information and click _Subscribe_.
+1. [Download and install](https://fly.io/docs/flyctl/installing/) the Fly CLI
+1. From the command line, sign up for Fly: `flyctl auth signup`.  You can sign up with an email address or with a GitHub account.
+1. Fill in credit card information and click _Subscribe_.
 
 ## Build and deploy a container
 
-1. Change in to the `web` directory: `cd web`.
-2. Create an app using `flyctl launch`.  You can choose your own app name or press enter to let Fly pick an app name. Choose a region for deployment (it should default to the closest one to you). Choose _No_ for DB. Choose _No_ to deploy now.
-3. Make the following changes to the `fly.toml` file.
+1. Create an app using `flyctl launch`.  You can choose your own app name or press enter to let Fly pick an app name. Choose a region for deployment (it should default to the closest one to you). Choose _No_ for DB. Choose _No_ to deploy now.
+1. To create a new app in the Partner Dashboard or to link the app to an existing app, run the following command using your preferred package manager:
+
+      Using yarn:
+
+      ```shell
+      yarn run info --web-env
+      ```
+
+      Using npm:
+
+      ```shell
+      npm run info --web-env
+      ```
+
+      Using pnpm:
+
+      ```shell
+      pnpm run info --web-env
+      ```
+
+      Take note of the `SCOPES`, `SHOPIFY_API_KEY` and the `SHOPIFY_API_SECRET` values, as you'll need them in the next steps.
+
+1. Make the following changes to the `fly.toml` file.
 
     - In the `[env]` section, add the following environment variables (in a `"` delimited string):
 
         |Variable|Description/value|
         |-|-|
         |`BACKEND_PORT`|The port on which to run the app; set to the same value as the `EXPOSE` line in the `Dockerfile` (`Dockerfile` default value is `8081`.|
-        |`HOST`|set to the URL of the new app; this can be constructed by taking the `app` variable at the very top of the `fly.toml` file, prepending it with `https://` and adding `.fly.dev` to the end, e.g, if `app` is `"fancy-cloud-1234"`, then `HOST` should be set to `https://fancy-cloud-1234.fly.dev`|
-        |`SCOPES`|comma-separated scopes for your app; the default for the unmodified template is `write_products`|
-        |`SHOPIFY_API_KEY`|API key for your app, from the Partners Dashboard|
+        |`HOST`|Set this to the URL of the new app, which can be constructed by taking the `app` variable at the very top of the `fly.toml` file, prepending it with `https://` and adding `.fly.dev` to the end, e.g, if `app` is `"fancy-cloud-1234"`, then `HOST` should be set to `https://fancy-cloud-1234.fly.dev`|
+        |`SCOPES`|Can be obtained from the `run info --web-env` command in the previous step|
+        |`SHOPIFY_API_KEY`|Can be obtained from the `run info --web-env` command in the previous step|
 
     - In the `[[services]]` section, change the value of `internal_port` to match the `BACKEND_PORT` value.
 
@@ -33,7 +54,7 @@
         BACKEND_PORT = "8081"
         HOST = "https://fancy-cloud-1234.fly.dev"
         SCOPES = "write_products"
-        SHOPIFY_API_KEY = "ReplaceWithKEYFromPartnerDashboard"
+        SHOPIFY_API_KEY = "ReplaceWithKEYFromEnvCommnd"
 
       :
       :
@@ -44,32 +65,47 @@
       :
       ```
 
-4. Set the API secret environment variable for your app:
+1. Set the API secret environment variable for your app:
 
     ```shell
-    flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromPartnerDashboard
+    flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromEnvCommnd
     ```
 
-5. Build and deploy the app - note that you'll need the `SHOPIFY_API_KEY` to pass to the command
+1. Build and deploy the app - note that you'll need the `SHOPIFY_API_KEY` to pass to the command
 
     ```shell
-    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromPartnerDashboard
+    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommnd --remote-only
     ```
 
 ## Update URLs in Partner Dashboard and test your app
 
-1. In the Partner Dashboard, update the main URL for your app to the value of url from the [fly.io dashboard](https://fly.io/dashboard) and set a callback URL to the same url with `/api/auth/callback` appended to it.  Note: this is the same as the `HOST` environment variable set in the `fly.toml` file.
-2. Open the deployed app by browsing to `https://fancy-cloud-1234.fly.dev/api/auth?shop=my-dev-shop-name.myshopify.com`
+1. Update main and callback URLs in Partner Dashboard to point to new app.  The main app URL should point to
+
+    ```text
+    https://my-app-name.fly.dev
+    ```
+
+    and the callback URL should be
+
+    ```text
+    https://my-app-name.fly.dev/api/auth/callback
+    ```
+
+1. Test the deployed app by browsing to
+
+   ```text
+   https://my-app-name.fly.dev/api/auth?shop=my-dev-shop-name.myshopify.com
+   ```
 
 ## Deploy a new version of the app
 
 1. After updating your code with new features and fixes, rebuild and redeploy using:
 
     ```shell
-    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKeyFromPartnerDashboard
+    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommnd --remote-only
     ```
 
 ## To scale to multiple regions
 
 1. Add a new region using `flyctl regions add CODE`, where `CODE` is the three-letter code for the region.  To obtain a list of regions and code, run `flyctl platform regions`.
-2. Scale to two instances - `flyctl scale count 2`
+1. Scale to two instances - `flyctl scale count 2`

--- a/web/docs/fly-io.md
+++ b/web/docs/fly-io.md
@@ -54,7 +54,7 @@
         BACKEND_PORT = "8081"
         HOST = "https://fancy-cloud-1234.fly.dev"
         SCOPES = "write_products"
-        SHOPIFY_API_KEY = "ReplaceWithKEYFromEnvCommnd"
+        SHOPIFY_API_KEY = "ReplaceWithKEYFromEnvCommand"
 
       :
       :
@@ -68,13 +68,13 @@
 1. Set the API secret environment variable for your app:
 
     ```shell
-    flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromEnvCommnd
+    flyctl secrets set SHOPIFY_API_SECRET=ReplaceWithSECRETFromEnvCommand
     ```
 
 1. Build and deploy the app - note that you'll need the `SHOPIFY_API_KEY` to pass to the command
 
     ```shell
-    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommnd --remote-only
+    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommand --remote-only
     ```
 
 ## Update URLs in Partner Dashboard and test your app
@@ -102,7 +102,7 @@
 1. After updating your code with new features and fixes, rebuild and redeploy using:
 
     ```shell
-    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommnd --remote-only
+    flyctl deploy --build-arg SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommand --remote-only
     ```
 
 ## To scale to multiple regions

--- a/web/docs/heroku.md
+++ b/web/docs/heroku.md
@@ -18,14 +18,41 @@ git commit -m "Initial version"
 ## Build and deploy from Git to a Docker container
 
 1. Login to Heroku Container Registry: `heroku container:login`
-1. Create an app in Heroku using `heroku create -a my-app-name -s container`. This will configure Heroku with a container-based app and create a git remote named `heroku` for deploying the app.  It will also return the URL to where the app will run when deployed, in the form of `https://my-app-name.herokuapp.com`
+1. Create an app in Heroku using `heroku create -a my-app-name -s container`. This will configure Heroku with a container-based app and create a git remote named `heroku` for deploying the app.  It will also return the URL to where the app will run when deployed, in the form of:
+
+    ```text
+    https://my-app-name.herokuapp.com
+    ```
+
+1. To create a new app in the Partner Dashboard or to link the app to an existing app, run the following command using your preferred package manager:
+
+    Using yarn:
+
+    ```shell
+    yarn run info --web-env
+    ```
+
+    Using npm:
+
+    ```shell
+    npm run info --web-env
+    ```
+
+    Using pnpm:
+
+    ```shell
+    pnpm run info --web-env
+    ```
+
+    Take note of the `SCOPES`, `SHOPIFY_API_KEY` and the `SHOPIFY_API_SECRET` values, as you'll need them in the next steps.
+
 1. Configure the environment variables `HOST`, `SCOPES`, `SHOPIFY_API_KEY`, and `SHOPIFY_API_SECRET` for your app.  For example:
 
     ```shell
     heroku config:set HOST=https://my-app-name.herokuapp.com
     heroku config:set SCOPES=write_products
-    heroku config:set SHOPIFY_API_KEY=ReplaceWithKEYFromPartnerDashboard
-    heroku config:set SHOPIFY_API_SECRET=ReplaceWithSECRETFromPartnerDashboard
+    heroku config:set SHOPIFY_API_KEY=ReplaceWithKEYFromEnvCommand
+    heroku config:set SHOPIFY_API_SECRET=ReplaceWithSECRETFromEnvCommand
     ```
 
     Note that these commands can be combined into a single command:
@@ -41,7 +68,7 @@ git commit -m "Initial version"
       docker:
         web: web/Dockerfile
       config:
-        SHOPIFY_API_KEY: ReplaceWithKEYFromPartnerDashboard
+        SHOPIFY_API_KEY: ReplaceWithKEYFromEnvCommand
     ```
 
     Commit the `heroku.yml` file to your git repository:

--- a/web/docs/heroku.md
+++ b/web/docs/heroku.md
@@ -66,7 +66,7 @@ git commit -m "Initial version"
     ```yaml
     build:
       docker:
-        web: web/Dockerfile
+        web: Dockerfile
       config:
         SHOPIFY_API_KEY: ReplaceWithKEYFromEnvCommand
     ```


### PR DESCRIPTION
### WHY are these changes introduced?

To remove friction in the user guide - changing directories for hosting deployments and CLI use

### WHAT is this pull request doing?

- Moves the `Dockerfile` and `.dockerignore` files up a level
- Changes the instructions accordingly

### Tested on ...

- [x] `fly.io` with `yarn`
- [x] Heroku with `yarn`