### PR TITLE
Remove React dependency in the root.  It is only needed inside the we…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@shopify/app": "^3.0.0",
-    "@shopify/cli": "^3.0.0",
-    "react": "17.0.2"
+    "@shopify/cli": "^3.0.0"
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
React is not needed as a top level dependency. I suspect this is left over from the old template.

### WHAT is this pull request doing?
Remove the React dependency.

### Tophatting
Run `yarn`. Do the dependencies install ?