### PR TITLE
Add chargeName param to ensureBilling

### DIFF
--- a/web/helpers/__tests__/ensure-billing.test.js
+++ b/web/helpers/__tests__/ensure-billing.test.js
@@ -1,10 +1,9 @@
 import { Shopify } from "@shopify/shopify-api";
 import { describe, expect, test, vi } from "vitest";
 
-import ensureBilling, {
-  BillingInterval,
-  SHOPIFY_CHARGE_NAME,
-} from "../ensure-billing";
+import ensureBilling, { BillingInterval } from "../ensure-billing";
+
+const SHOPIFY_CHARGE_NAME = "Shopify app test billing";
 
 describe("ensureBilling", async () => {
   const session = new Shopify.Session.Session("1", "test-shop", "state", true);
@@ -20,6 +19,7 @@ describe("ensureBilling", async () => {
       ]);
 
       const [hasPayment, confirmationUrl] = await ensureBilling(session, {
+        chargeName: SHOPIFY_CHARGE_NAME,
         amount: 5.0,
         interval: BillingInterval.OneTime,
       });
@@ -53,6 +53,7 @@ describe("ensureBilling", async () => {
       ]);
 
       const [hasPayment, confirmationUrl] = await ensureBilling(session, {
+        chargeName: SHOPIFY_CHARGE_NAME,
         amount: 5.0,
         interval: BillingInterval.Every30Days,
       });
@@ -83,6 +84,7 @@ describe("ensureBilling", async () => {
       const spy = mockGraphQLQueries([EXISTING_ONE_TIME_PAYMENT]);
 
       const [hasPayment, confirmationUrl] = await ensureBilling(session, {
+        chargeName: SHOPIFY_CHARGE_NAME,
         amount: 5.0,
         interval: BillingInterval.OneTime,
       });
@@ -108,6 +110,7 @@ describe("ensureBilling", async () => {
       ]);
 
       const [hasPayment, confirmationUrl] = await ensureBilling(session, {
+        chargeName: SHOPIFY_CHARGE_NAME,
         amount: 5.0,
         interval: BillingInterval.OneTime,
       });
@@ -138,6 +141,7 @@ describe("ensureBilling", async () => {
       const spy = mockGraphQLQueries(EXISTING_ONE_TIME_PAYMENT_WITH_PAGINATION);
 
       const [hasPayment, confirmationUrl] = await ensureBilling(session, {
+        chargeName: SHOPIFY_CHARGE_NAME,
         amount: 5.0,
         interval: BillingInterval.OneTime,
       });
@@ -170,6 +174,7 @@ describe("ensureBilling", async () => {
       const spy = mockGraphQLQueries([EXISTING_SUBSCRIPTION]);
 
       const [hasPayment, confirmationUrl] = await ensureBilling(session, {
+        chargeName: SHOPIFY_CHARGE_NAME,
         amount: 5.0,
         interval: BillingInterval.Annual,
       });

--- a/web/index.js
+++ b/web/index.js
@@ -47,6 +47,7 @@ Shopify.Webhooks.Registry.addHandler("APP_UNINSTALLED", {
 const BILLING_SETTINGS = {
   required: false,
   // This is an example configuration that would do a one-time charge for $5 (only USD is currently supported)
+  // chargeName: "My Shopify One-Time Charge",
   // amount: 5.0,
   // currencyCode: "USD",
   // interval: BillingInterval.OneTime,


### PR DESCRIPTION
### WHY are these changes introduced?

If multiple apps built on the same template are used by the same store, they'll be presented with the same charge name as it's a const within the billing functionality.

Closes https://github.com/Shopify/first-party-library-planning/issues/364

### WHAT is this pull request doing?

- Adds a 'chargeName' to the `BILLING_SETTINGS` example in `index.js`
- Updates `ensureBilling` and associated tests to account for the configuration parameter

## Checklist

- [x] I have added/updated tests for this change
