### PR TITLE
Update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,50 @@
 version: 2
 updates:
-  # Enable version updates for npm
+  # Enable version updates for npm - main (old template)
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+
+  # Enable version updates for npm - cli_two (old template)
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+    # Raise PRs for version updates to npm against the `cli_two` branch
+    target-branch: "cli_two"
+    # Labels on pull requests for version updates only
+    labels:
+      - "cli_two dependencies"
+
+  # Enable version updates for npm - cli_three/ (new template)
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    # This will be CLI dependencies only
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+    # Raise PRs for version updates to npm against the `cli_two` branch
+    target-branch: "cli_three"
+    # Labels on pull requests for version updates only
+    labels:
+      - "cli_three dependencies"
+
+  # Enable version updates for npm - cli_three/web (new template)
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    # This will be CLI dependencies only
+    directory: "/web"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+    # Raise PRs for version updates to npm against the `cli_two` branch
+    target-branch: "cli_three"
+    # Labels on pull requests for version updates only
+    labels:
+      - "cli_three dependencies"


### PR DESCRIPTION
### WHY are these changes introduced?

Dependabot is only running for `main` branch, `root` folder

### WHAT is this pull request doing?

Make dependabot look at
- `main`,  root directory
- `cli_two`, root diretory
- `cli_three`, root and `web` directories
