### PR TITLE
Set `isOnline` param based on global `use-online-tokens` value

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -62,7 +62,11 @@ export async function createServer(
   });
 
   app.get("/products-count", verifyRequest(app), async (req, res) => {
-    const session = await Shopify.Utils.loadCurrentSession(req, res, true);
+    const session = await Shopify.Utils.loadCurrentSession(
+      req,
+      res,
+      app.get("use-online-tokens")
+    );
     const { Product } = await import(
       `@shopify/shopify-api/dist/rest-resources/${Shopify.Context.API_VERSION}/index.js`
     );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,7 @@ export default function App() {
       <AppBridgeProvider
         config={{
           apiKey: process.env.SHOPIFY_API_KEY,
-          host: new URL(location).searchParams.get("host"),
+          host: new URL(location.href).searchParams.get("host"),
           forceRedirect: true,
         }}
       >


### PR DESCRIPTION
### WHY are these changes introduced?

When `USE_ONLINE_TOKENS` is being set to `false` (to use offline tokens), then the app will crash as `loadCurrentSession()` takes `true` as a third argument which is `isOnline` parameter. It may lead to some confusion. Of course, it can be changed manually but `Shopify.Utils.loadCurrentSession(...)` should rely on global variable from `app.get("use-online-tokens")`

### WHAT is this pull request doing?

Changes hardcoded `true` value for `isOnline` param to global variable from `app.get("use-online-tokens")`

Second commit: also using `location.href` instead of `location` is more correct as `new URL(input[, base])` takes `string` as a first param.
