### PR TITLE
Fix npm init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ yarn create @shopify/app
 Using npx:
 
 ```shell
-npm init @shopify/app
+npm init @shopify/app@latest
 ```
 
 Using pnpm:


### PR DESCRIPTION
### WHY are these changes introduced?

`npm init` caches heavily, hence need to force it to get the latest version

### WHAT is this pull request doing?

Change the `npm init @shopify/app` to `npm init @shopify/app@latest`