### PR TITLE
Skip index.html file when serving static content

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -148,7 +148,7 @@ export async function createServer(
       ({ default: fn }) => fn
     );
     app.use(compression());
-    app.use(serveStatic(PROD_INDEX_PATH));
+    app.use(serveStatic(PROD_INDEX_PATH, { index: false }));
   }
 
   app.use("/*", async (req, res, next) => {


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #932

The app is set up to serve static content in production from the FE build output path. When a path doesn't map to a static file, we use the fallback endpoint to render the React app (thus using its client-side routing to render the correct page) and trigger OAuth when needed.

By default, the `serveStatic` middleware will default `/` to `/index.html`, which is not a behaviour we want here - we want to use the fallback for the root address, to ensure the app is installed before rendering it.

### WHAT is this pull request doing?

Disabling the default `/index.html` behaviour for the `serveStatic` middleware.
