### PR TITLE
Add note regarding express.json middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ The following pages document the basic steps to host and deploy your application
 - [fly.io](/web/docs/fly-io.md)
 - [Heroku](/web/docs/heroku.md)
 
+## Some things to watch out for
+
+### Using `express.json` middleware
+
+If you use the `express.json()` middleware in your app **and** if you use `Shopify.Webhooks.Registry.process()` to process webhooks API calls from Shopify (which we recommend), the webhook processing must occur ***before*** calling `app.use(express.json())`.  See the [API documentation](https://github.com/Shopify/shopify-api-node/blob/main/docs/usage/webhooks.md#note-regarding-express) for more details.
+
 ## Known issues
 
 ### Hot module replacement and Firefox
@@ -211,7 +217,7 @@ SHOPIFY_VITE_HMR_USE_POLLING=1 pnpm dev
 
 When you’re previewing your app or extension, you might see an ngrok interstitial page with a warning:
 
-```
+```text
 You are about to visit <id>.ngrok.io: Visit Site
 ```
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The following pages document the basic steps to host and deploy your application
 
 ### Using `express.json` middleware
 
-If you use the `express.json()` middleware in your app **and** if you use `Shopify.Webhooks.Registry.process()` to process webhooks API calls from Shopify (which we recommend), the webhook processing must occur ***before*** calling `app.use(express.json())`.  See the [API documentation](https://github.com/Shopify/shopify-api-node/blob/main/docs/usage/webhooks.md#note-regarding-express) for more details.
+If you use the `express.json()` middleware in your app **and** if you use `Shopify.Webhooks.Registry.process()` to process webhooks API calls from Shopify (which we recommend), the webhook processing must occur ***before*** calling `app.use(express.json())`.  See the [API documentation](https://github.com/Shopify/shopify-api-node/blob/main/docs/usage/webhooks.md#note-regarding-use-of-body-parsers) for more details.
 
 ## Known issues
 

--- a/web/index.js
+++ b/web/index.js
@@ -137,7 +137,8 @@ export async function createServer(
     res.status(status).send({ success: status === 200, error });
   });
 
-  // All endpoints after this point will use the express.json() middleware
+  // All endpoints after this point will have access to a request.body
+  // attribute, as a result of the express.json() middleware
   app.use(express.json());
 
   app.use((req, res, next) => {

--- a/web/index.js
+++ b/web/index.js
@@ -80,6 +80,10 @@ export async function createServer(
     billing: billingSettings,
   });
 
+  // Do not call app.use(express.json()) before processing webhooks with
+  // Shopify.Webhooks.Registry.process().
+  // See https://github.com/Shopify/shopify-api-node/blob/main/docs/usage/webhooks.md#note-regarding-express
+  // for more details.
   app.post("/api/webhooks", async (req, res) => {
     try {
       await Shopify.Webhooks.Registry.process(req, res);
@@ -133,6 +137,7 @@ export async function createServer(
     res.status(status).send({ success: status === 200, error });
   });
 
+  // All endpoints after this point will use the express.json() middleware
   app.use(express.json());
 
   app.use((req, res, next) => {


### PR DESCRIPTION
### WHY are these changes introduced?

Use of `express.json()` middleware must occur after processing webhook requests with `Shopify.Webhooks.Registry.process()`.

### WHAT is this pull request doing?

Add some documentation about ☝🏻 
