### PR TITLE
Drop node to v14 in supported engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, "lts/*"]
+        node-version: [14, 16, 18]
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, "lts/*"]
+        node-version: [14, 16, "lts/*"]
 
     defaults:
       run:

--- a/web/__tests__/server.test.js
+++ b/web/__tests__/server.test.js
@@ -271,7 +271,7 @@ describe("shopify-app-template-node server", async () => {
 
       expect(response.status).toEqual(400);
       expect(consoleSpy).toHaveBeenCalled();
-      expect(consoleSpy.mock.lastCall[0]).toContain("something went wrong");
+      expect(consoleSpy.mock.calls[0][0]).toContain("something went wrong");
     });
   });
 

--- a/web/helpers/ensure-billing.js
+++ b/web/helpers/ensure-billing.js
@@ -105,7 +105,7 @@ async function requestPayment(
   const client = new Shopify.Clients.Graphql(session.shop, session.accessToken);
   const returnUrl = `https://${Shopify.Context.HOST_NAME}?shop=${
     session.shop
-  }&host=${btoa(`${session.shop}/admin`)}`;
+  }&host=${Buffer.from(`${session.shop}/admin`).toString('base64')}`;
 
   let data;
   if (isRecurring(interval)) {

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=16.13.0"
+    "node": ">=14.13.1"
   },
   "dependencies": {
     "@shopify/shopify-api": "^4.0.0",


### PR DESCRIPTION
### WHY are these changes introduced?

CLI 3 supports Node version 14, whereas this template specifies Node 16 as the minimum engine.

### WHAT is this pull request doing?

Downgrade Node engine requirement from 16 to 14 to align with CLI.
