### PR TITLE
Fix link in comment to correct anchor

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -81,7 +81,7 @@ export async function createServer(
 
   // Do not call app.use(express.json()) before processing webhooks with
   // Shopify.Webhooks.Registry.process().
-  // See https://github.com/Shopify/shopify-api-node/blob/main/docs/usage/webhooks.md#note-regarding-express
+  // See https://github.com/Shopify/shopify-api-node/blob/main/docs/usage/webhooks.md#note-regarding-use-of-body-parsers
   // for more details.
   app.post("/api/webhooks", async (req, res) => {
     try {


### PR DESCRIPTION
### WHY are these changes introduced?

Link in comment directing devs to webhooks docs in API repo s incorrect.

### WHAT is this pull request doing?

Update the URL to the correct one.