### PR TITLE
Add error handling to productCreator

### DIFF
--- a/web/helpers/product-creator.js
+++ b/web/helpers/product-creator.js
@@ -82,8 +82,8 @@ const CREATE_PRODUCTS_MUTATION = `
 export default async function productCreator(session, count = DEFAULT_PRODUCTS_COUNT) {
   const client = new Shopify.Clients.Graphql(session.shop, session.accessToken);
 
-  for (let i = 0; i < count; i++) {
-    try {
+  try {
+    for (let i = 0; i < count; i++) {
       await client.query({
         data: {
           query: CREATE_PRODUCTS_MUTATION,
@@ -95,14 +95,12 @@ export default async function productCreator(session, count = DEFAULT_PRODUCTS_C
           },
         },
       });
-    } catch (error) {
-      let message;
-      if (error instanceof ShopifyErrors.GraphqlQueryError) {
-        message = `${error.message}\n${JSON.stringify(error.response, null, 2)}`;
-      } else {
-        message = error.message;
-      }
-      throw new Error(message);
+    }
+  } catch (error) {
+    if (error instanceof ShopifyErrors.GraphqlQueryError) {
+      throw new Error(`${error.message}\n${JSON.stringify(error.response, null, 2)}`);
+    } else {
+      throw error;
     }
   }
 }

--- a/web/helpers/product-creator.js
+++ b/web/helpers/product-creator.js
@@ -83,17 +83,27 @@ export default async function productCreator(session, count = DEFAULT_PRODUCTS_C
   const client = new Shopify.Clients.Graphql(session.shop, session.accessToken);
 
   for (let i = 0; i < count; i++) {
-    await client.query({
-      data: {
-        query: CREATE_PRODUCTS_MUTATION,
-        variables: {
-          input: {
-            title: `${randomTitle()}`,
-            variants: [{ price: randomPrice() }],
+    try {
+      await client.query({
+        data: {
+          query: CREATE_PRODUCTS_MUTATION,
+          variables: {
+            input: {
+              title: `${randomTitle()}`,
+              variants: [{ price: randomPrice() }],
+            },
           },
         },
-      },
-    });
+      });
+    } catch (error) {
+      let message;
+      if (error instanceof ShopifyErrors.GraphqlQueryError) {
+        message = `${error.message}\n${JSON.stringify(error.response, null, 2)}`;
+      } else {
+        message = error.message;
+      }
+      throw new Error(message);
+    }
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The GraphQL client query method now throws an error if the server returns an error.

Note this depends on the merger and release of https://github.com/Shopify/shopify-api-node/pull/431

Template component of https://github.com/Shopify/first-party-library-planning/issues/385

### WHAT is this pull request doing?

Updates the `productCreator` method to handle this and to generate a meaningful error message.