### PR TITLE
remove pointless useCallback

### DIFF
--- a/src/components/ProductsCard.jsx
+++ b/src/components/ProductsCard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import {
   Card,
   Heading,
@@ -29,14 +29,12 @@ export function ProductsCard() {
 
   const app = useAppBridge();
   const fetch = userLoggedInFetch(app);
-  const updateProductCount = useCallback(async () => {
+  const updateProductCount = async () => {
     const { count } = await fetch("/products-count").then((res) => res.json());
     setProductCount(count);
-  }, []);
+  };
 
-  useEffect(() => {
-    updateProductCount();
-  }, [updateProductCount]);
+  useEffect(updateProductCount, []);
 
   const toastMarkup = hasResults && (
     <Toast


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

`useCallback` is there so that you have a non-changing value that can be passed down without needless updates caused by that.
`useEffect` just runs the given function. The only reason `useCallback` was used here is so that the dependency list of `useEffect` does not change. By just passing the function directly, putting it into the deps list is not even required.

### WHAT is this pull request doing?

Simplifying the code while maintaining functionality.
