### PR TITLE
Improve query argument sanitization

### DIFF
--- a/web/helpers/top-level-auth-redirect.js
+++ b/web/helpers/top-level-auth-redirect.js
@@ -1,4 +1,6 @@
 export default function topLevelAuthRedirect({ apiKey, hostName, shop }) {
+  const serializedQuery = new URLSearchParams({ shop }).toString();
+
   return `<!DOCTYPE html>
 <html>
   <head>
@@ -16,17 +18,17 @@ export default function topLevelAuthRedirect({ apiKey, hostName, shop }) {
 
           const app = createApp({
             apiKey: '${apiKey}',
-            shopOrigin: '${shop}',
+            shopOrigin: ${JSON.stringify(shop).replaceAll(["<", ">"], "")},
           });
 
           const redirect = Redirect.create(app);
 
           redirect.dispatch(
             Redirect.Action.REMOTE,
-            'https://${hostName}/api/auth/toplevel?shop=${shop}',
+            'https://${hostName}/api/auth/toplevel?${serializedQuery}',
           );
         } else {
-          window.location.href = '/api/auth?shop=${shop}';
+          window.location.href = '/api/auth?${serializedQuery}';
         }
       });
     </script>

--- a/web/middleware/verify-request.js
+++ b/web/middleware/verify-request.js
@@ -23,11 +23,10 @@ export default function verifyRequest(
       app.get("use-online-tokens")
     );
 
-    let shop = req.query.shop;
-
+    let shop = Shopify.Utils.sanitizeShop(req.query.shop);
     if (session && shop && session.shop !== shop) {
       // The current request is for a different shop. Redirect gracefully.
-      return res.redirect(`/api/auth?shop=${shop}`);
+      return res.redirect(`/api/auth?shop=${encodeURIComponent(shop)}`);
     }
 
     if (session?.isActive()) {
@@ -82,6 +81,10 @@ export default function verifyRequest(
       }
     }
 
-    returnTopLevelRedirection(req, res, `/api/auth?shop=${shop}`);
+    returnTopLevelRedirection(
+      req,
+      res,
+      `/api/auth?shop=${encodeURIComponent(shop)}`
+    );
   };
 }

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.13.1"
   },
   "dependencies": {
-    "@shopify/shopify-api": "^4.2.0",
+    "@shopify/shopify-api": "^5.0.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
### WHY are these changes introduced?

If we get malformed shop names in the query args, we're currently still trying to use them, even though it's bound to fail when we reach Shopify.

### WHAT is this pull request doing?

Improving our sanitization of the arguments we receive, and properly escaping them when embedding them in strings.