### PR TITLE
Fix infinite loop issue in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environment Configuration
 .env
+.env.*
 
 # Dependency directory
 node_modules

--- a/web/index.js
+++ b/web/index.js
@@ -164,7 +164,6 @@ export async function createServer(
   }
 
   app.use("/*", async (req, res, next) => {
-
     if (typeof req.query.shop !== "string") {
       res.status(500);
       return res.send("No shop provided");
@@ -173,7 +172,7 @@ export async function createServer(
     const shop = Shopify.Utils.sanitizeShop(req.query.shop);
     const appInstalled = await AppInstallations.includes(shop);
 
-    if (!appInstalled) {
+    if (!appInstalled && !req.originalUrl.match(/^\/exitiframe/i)) {
       return redirectToAuth(req, res, app);
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

There was a scenario in production where we could end up on a redirect loop if the production DB got wiped, but Shopify still thinks the app is installed (unlikely but you never know).

We would redirect to `/exitiframe` upon learning that we needed to break out of the iframe, which in production gets rendered by the `/*` route, which would trigger another redirect.

### WHAT is this pull request doing?

Letting requests to `/exitiframe` go through to the client-side where it'll get properly rendered by the React app.