### PR TITLE
Fix installation from CLI with localhost URL

### DIFF
--- a/web/middleware/auth.js
+++ b/web/middleware/auth.js
@@ -31,7 +31,7 @@ export default function applyAuthMiddleware(
         // 'GDPR mandatory webhooks' section of 'App setup' in the Partners Dashboard.
         if (!response.success && !gdprTopics.includes(topic)) {
           console.log(
-            `Failed to register ${topic} webhook: ${response.result.errors[0].message}`
+            `Failed to register ${topic} webhook: ${response.result.errors?.[0]?.message}`
           );
         }
       });


### PR DESCRIPTION
### WHY are these changes introduced?

We have just released a new version of the CLI that uses localhost by default (instead of a tunnel), but the installation is failing when trying to show a warning about a webhook that couldn't be registered:

```
backend  | TypeError: Cannot read properties of undefined (reading '0')
backend  |     at file:///Users/gonzalo/src/tests/sept20/web/middleware/auth.js:34:75
backend  |     at Array.map (<anonymous>)
backend  |     at file:///Users/gonzalo/src/tests/sept20/web/middleware/auth.js:28:33
backend  |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Steps to reproduce:
- `yarn create @Shopify/app`
- `yarn dev`
- Create a new app and install it

### WHAT is this pull request doing?

Avoid crashing by reading the error message with safe navigation operators.

With this change, we are showing instead:

```
backend  | Failed to register APP_UNINSTALLED webhook: undefined
```