### PR TITLE
Add more logging for webhook registration failure

### DIFF
--- a/web/middleware/auth.js
+++ b/web/middleware/auth.js
@@ -35,12 +35,10 @@ export default function applyAuthMiddleware(
               `Failed to register ${topic} webhook: ${response.result.errors[0].message}`
             );
           } else {
-            // There should be an error message at data.X.userErrors[0].message, where X is one of
-            //   webhookSubscriptionCreate, webhookSubscriptionUpdate,
-            //   eventBridgeWebhookSubscriptionCreate, eventBridgeWebhookSubscriptionUpdate
-            //   pubSubWebhookSubscriptionCreate, pubSubWebhookSubscriptionUpdate
             console.log(
-              `Failed to register ${topic} webhook: ${JSON.stringify(response.result.data)}`
+              `Failed to register ${topic} webhook: ${
+                JSON.stringify(response.result.data, undefined, 2)
+              }`
             );
           }
         }


### PR DESCRIPTION
### WHY are these changes introduced?

The current code assumes that there will be a `response.result.errors` property that can be logged when there's a webhook failure.  However, there's an alternative result structure in the error case, where the message is located at `response.result.data.X.userErrors[0].message`, where `X` is one of 
- `webhookSubscriptionCreate`
- `webhookSubscriptionUpdate`
- `eventBridgeWebhookSubscriptionCreate`
- `eventBridgeWebhookSubscriptionUpdate`
- `pubSubWebhookSubscriptionCreate`
- `pubSubWebhookSubscriptionUpdate`

This was highlighted by attempting to register a webhook with a `http` path.

### WHAT is this pull request doing?

Adds an `if`/`else` statement that logs either `response.result.errors[0].message` if `response.result.errors` is present, or do a `JSON.stringify(response.result.data)` otherwise.

Enhancement to https://github.com/Shopify/shopify-app-template-node/pull/1058
