### PR TITLE
[WIP] Add SHOPIFY_API_KEY to DB_PATH when creating database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ dist/
 extensions/*/build
 
 # Node library SQLite database
-web/database.sqlite
+web/*.sqlite
 
 # Partners can use npm, yarn or pnpm with the CLI.
 # We ignore lock files so they don't get a package manager mis-match

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Open the URL generated in your console. Once you grant permission to the app, yo
 
 ### Application Storage
 
-This template uses [SQLite](https://www.sqlite.org/index.html) to store session data. The database is a file called `database.sqlite` which is automatically created in the root. This use of SQLite works in production if your app runs as a single instance.
+This template uses [SQLite](https://www.sqlite.org/index.html) to store session data. The database is a file called `db_APIKEY.sqlite` (with `APIKEY` replaced with your app's actual API key) which is automatically created in the root. This use of SQLite works in production if your app runs as a single instance.
 
 The database that works best for you depends on the data your app needs and how it is queried. You can run your database of choice on a server yourself or host it with a SaaS company. Here’s a short list of databases providers that provide a free tier to get started:
 

--- a/web/index.js
+++ b/web/index.js
@@ -21,7 +21,7 @@ const PORT = parseInt(process.env.BACKEND_PORT || process.env.PORT, 10);
 const DEV_INDEX_PATH = `${process.cwd()}/frontend/`;
 const PROD_INDEX_PATH = `${process.cwd()}/frontend/dist/`;
 
-const DB_PATH = `${process.cwd()}/database.sqlite`;
+const DB_PATH = `${process.cwd()}/db_${process.env.SHOPIFY_API_KEY}.sqlite`;
 
 Shopify.Context.initialize({
   API_KEY: process.env.SHOPIFY_API_KEY,


### PR DESCRIPTION
### WHY are these changes introduced?

Running the following commands
```shell
# create a new app from the Node template
yarn create @shopify/app --template node
# run the app, creating a new app on the partner account
yarn dev
```
and then opening the provided link will successfully allow the installation of the app.

Doing the following command as a follow-on step
```shell
# run the app again, creating a different new app on the partner account
yarn dev --reset
```
and then opening the provided link will result in a "There's no page at this address" message.

Cause: running the app the second time uses the `database.sqlite` file created during the first `yarn dev`, resulting in the error.

### WHAT is this pull request doing?

When creating the database file, add the API_KEY in order to differentiate between different instances of the app.  The database filename (was `database.sqlite`) is now `db_${API_KEY}.sqlite`