### PR TITLE
unignore lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,3 @@ extensions/*/build
 
 # Node library SQLite database
 web/database.sqlite
-
-# Partners can use npm, yarn or pnpm with the CLI.
-# We ignore lock files so they don't get a package manager mis-match
-# Without this, they may get a warning if using a different package manager to us
-yarn.lock
-package-lock.json


### PR DESCRIPTION
### WHY are these changes introduced?

lock files ensure that different installs at different times produce the same result / install the same versions of dependencies.
If we omit them, partners could end up in a situation where code works locally or on CI, but stops working once pushed to production.

Imagine the following scenario:

`package.json` contains `react@^17.0.0`

- 10:00am CI run: `yarn` -> installs  `react@17.1.0` because that's the currently available version in the npm registry
- 10:05 am: react team publishes `react@17.2.0` which unfortunately contains a bug that breaks the app
- 10:07am: app is deployed to production and runs `yarn` again. That'd install   `react@17.2.0` now and break production albeit everything was fine in CI

More context: 

### WHAT is this pull request doing?

Remove lock files from .gitignore

The comment in the `.gitingore` mentioned

> We ignore lock files so they don't get a package manager mis-match

But I'm not sure this is going to be an issue because we already allow installation via different package managers. So if a partner uses `npm init @shopify/app@latest` to create the app, we already use `npm` to install its dependencies vs. `yarn` when they create the app via `yarn create @shopify/app`