### PR TITLE
[CLI_THREE] Fix product create error handling

### DIFF
--- a/web/helpers/product-creator.js
+++ b/web/helpers/product-creator.js
@@ -97,7 +97,7 @@ export default async function productCreator(session, count = DEFAULT_PRODUCTS_C
       });
     }
   } catch (error) {
-    if (error instanceof ShopifyErrors.GraphqlQueryError) {
+    if (error instanceof Shopify.Errors.GraphqlQueryError) {
       throw new Error(`${error.message}\n${JSON.stringify(error.response, null, 2)}`);
     } else {
       throw error;


### PR DESCRIPTION
Fix the product creation failure scenario handling, that currently leads to the current error being logged.

```
Failed to process products/create: ShopifyErrors is not defined
```

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
