### PR TITLE
Fix broken link to App Bridge React in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a sample app to help developers bootstrap their Shopify app development.
 
-It leverages the [Shopify API Library](https://github.com/Shopify/shopify-node-api) on the backend to create [an embedded app](https://shopify.dev/apps/tools/app-bridge/getting-started#embed-your-app-in-the-shopify-admin), and [Polaris](https://github.com/Shopify/polaris-react) and [App Bridge React](https://shopify.dev/tools/app-bridge/react-components) on the frontend.
+It leverages the [Shopify API Library](https://github.com/Shopify/shopify-node-api) on the backend to create [an embedded app](https://shopify.dev/apps/tools/app-bridge/getting-started#embed-your-app-in-the-shopify-admin), and [Polaris](https://github.com/Shopify/polaris-react) and [App Bridge React](https://shopify.dev/apps/tools/app-bridge/getting-started/using-react) on the frontend.
 
 This is the repository used when you create a new Node app with the [Shopify CLI](https://shopify.dev/apps/tools/cli).
 


### PR DESCRIPTION
### WHY are these changes introduced?

Noticed a broken link in the README.

### WHAT is this pull request doing?

Changes the link.

It was previously a "Getting Started" page (from [Internet Archive](https://web.archive.org/web/20210224225825/https://shopify.dev/tools/app-bridge/react-components))
 and so I linked to the new "Getting Started" page.