### PR TITLE
Remove trailing comma

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
     "@shopify/shopify-app-session-storage-sqlite": "^1.0.0-rc.0",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
-    "serve-static": "^1.14.1",
+    "serve-static": "^1.14.1"
   },
   "devDependencies": {
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
Trailing comma causes `yarn install` to fail.
