### PR TITLE
Fix example billing config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Shopify/learn-libs-superteam
+*       @shopify/client-libraries-app-templates

--- a/web/shopify.js
+++ b/web/shopify.js
@@ -24,7 +24,7 @@ const shopify = shopifyApp({
   api: {
     apiVersion: LATEST_API_VERSION,
     restResources,
-    billingConfig: undefined, // or replace with billingConfig above to enable example billing
+    billing: undefined, // or replace with billingConfig above to enable example billing
   },
   auth: {
     path: "/api/auth",


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, the template uses `billingConfig` for the example in `shopify.js`, which is incorrect: it should be `billing`.

### WHAT is this pull request doing?

Fixing the config name.