### PR TITLE
Update shopify-app-express

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.13.1"
   },
   "dependencies": {
-    "@shopify/shopify-app-express": "^1.0.0",
+    "@shopify/shopify-app-express": "^1.1.0",
     "@shopify/shopify-app-session-storage-sqlite": "^1.0.0",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",

--- a/web/shopify.js
+++ b/web/shopify.js
@@ -1,11 +1,7 @@
 import { BillingInterval, LATEST_API_VERSION } from "@shopify/shopify-api";
 import { shopifyApp } from "@shopify/shopify-app-express";
 import { SQLiteSessionStorage } from "@shopify/shopify-app-session-storage-sqlite";
-let { restResources } = await import(
-  `@shopify/shopify-api/rest/admin/${LATEST_API_VERSION}`
-);
-// If you want IntelliSense for the rest resources, you should import them directly
-// import { restResources } from "@shopify/shopify-api/rest/admin/2022-10";
+import { restResources } from "@shopify/shopify-api/rest/admin/2023-01";
 
 const DB_PATH = `${process.cwd()}/database.sqlite`;
 


### PR DESCRIPTION
This PR updates the dependency on `@shopify/shopify-app-express`, and leverages the ability to have a different API version for REST resources and the default to hard-code the import statement so that intellisense works out of the box.