### PR TITLE
Add proxy instructions for non-API routes

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -29,7 +29,9 @@ app.post(
   shopify.processWebhooks({ webhookHandlers: GDPRWebhookHandlers })
 );
 
-// All endpoints after this point will require an active session
+// If you are adding routes outside of the /api path, remember to
+// also add a proxy rule for them in web/frontend/vite.config.js
+
 app.use("/api/*", shopify.validateAuthenticatedSession());
 
 app.use(express.json());


### PR DESCRIPTION
In development mode, the frontend runs on a separate process, and proxies requests to the backend.

By default, that only happens for paths under /api, under the assumption that the app is a single-page application. When adding backend routes outside that path, it's important to remember that we need to add proxy exceptions too, or the FE will take over and render the react app in development.

This PR adds a comment to the index file to help remind folks about the proxy rules.