### PR TITLE
Update to app_express 2.1.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,8 +13,8 @@
     "node": ">=14.13.1"
   },
   "dependencies": {
-    "@shopify/shopify-app-express": "^2.0.0",
-    "@shopify/shopify-app-session-storage-sqlite": "^1.2.1",
+    "@shopify/shopify-app-express": "^2.1.1",
+    "@shopify/shopify-app-session-storage-sqlite": "^1.2.2",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
     "serve-static": "^1.14.1"


### PR DESCRIPTION
### WHY are these changes introduced?

`@shopify/shopify-app-express@2.1.1` released

### WHAT is this pull request doing?

Updating the dependencies to be the latest
