### PR TITLE
Add recommendation and config for i18n-ally

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
-    "shopify.polaris-for-vscode"
+    "shopify.polaris-for-vscode",
+    "lokalise.i18n-ally"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "i18n-ally.localesPaths": [
+    "web/frontend/locales"
+  ],
+  "i18n-ally.enabledFrameworks": [
+    "i18next-shopify"
+  ],
+  "i18n-ally.keystyle": "nested"
+}


### PR DESCRIPTION
### WHY are these changes introduced?

`i18next-shopify` (and associated dependencies) was recently added to this template repo (in the `web/frontend` folder).  This commit recommends the `i18n-ally` VS Code extension to aide in internationalization/translation efforts.

### WHAT is this pull request doing?

Adds `lokalise.i18n-ally` to `.vscode/extensions.json` file (recommendation) and adds `.vscode/settings.json` file with appropriate i18n-ally configuration for this template.
