### PR TITLE
Remove node 14 from CI and min dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [16, 18, 20]
 
     defaults:
       run:
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn install
+      - run: yarn install --ignore-engines
       - name: Build FE for production test
         working-directory: ./web/frontend
-        run: yarn install && yarn build
+        run: yarn install --ignore-engines && yarn build

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=14.13.1"
+    "node": ">=16.13.0"
   },
   "dependencies": {
     "@shopify/shopify-app-express": "^2.1.3",


### PR DESCRIPTION
### WHY are these changes introduced?

* Node 14 has been EOL for a while, and our libraries [removed support from months ago](https://github.com/Shopify/shopify-app-js/pull/459).
* Node 16 is also currently EOL but we are currently still supporting it, so `--ignore-engines` flag was added to get our [CI passing again](https://github.com/Shopify/shopify-app-template-node/actions/runs/8087252698/job/22098773560?pr=1319).
* Looks like we [previously were on Node 16](https://github.com/Shopify/shopify-app-template-node/pull/941/files) on the template so no updates are necessary.


### Checklist
This was tested by creating a new app with the CLI using this branch as the template.

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
