### PR TITLE
Fix server-side rendering for App Bridge v4

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -67,7 +67,11 @@ app.use("/*", shopify.ensureInstalledOnShop(), async (_req, res, _next) => {
   return res
     .status(200)
     .set("Content-Type", "text/html")
-    .send(readFileSync(join(STATIC_PATH, "index.html")));
+    .send(
+      readFileSync(join(STATIC_PATH, "index.html"))
+        .toString()
+        .replace("%VITE_SHOPIFY_API_KEY%", process.env.SHOPIFY_API_KEY || "")
+    );
 });
 
 app.listen(PORT);


### PR DESCRIPTION
### WHY are these changes introduced?

As part of [updating the template to use App Bridge React v4](https://github.com/Shopify/shopify-frontend-template-react/pull/255), we'll need to include the api key in the `index.html` file, which is served by the backend of the app.

Vite will handle replacing it in client-side renders, which is why the variable needs to start with a `VITE_`.

### WHAT is this pull request doing?

Dynamically replacing the api key when serving that file.