### PR TITLE
[Chore] Increase maximum dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    # Dependabot defaults to 5 open pull requests at a time
+    open-pull-requests-limit: 100


### PR DESCRIPTION
This PR increases the number of open dependabot PRs (which defaults to 5) so we don't miss any updates.